### PR TITLE
Fix broken deploy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(name='YourAppName',
       author='Your Name',
       author_email='example@example.com',
       url='http://www.python.org/sigs/distutils-sig/',
-      install_requires=['ReviewBoard', 'Markdown', 'docutils'],
+      install_requires=['ReviewBoard', 'Markdown==2.4', 'docutils'],
 			dependency_links = ['https://www.djangoproject.com/download/1.4.5/tarball/#egg=Django-1.4.5',],
      )


### PR DESCRIPTION
By default, 2.6 version of Markdown is installed but this causes troubles. 
This is how I fixed and deployed without errors ReviewBoard.
Thanks.